### PR TITLE
fix: increase MaxListeners limit to prevent AbortSignal warnings

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,10 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { setMaxListeners } from "node:events";
+
+// Increase limit to prevent MaxListeners warnings from AbortSignal in HTTP requests
+setMaxListeners(20);
 import {
 	Agent,
 	type AgentEvent,


### PR DESCRIPTION
The pi-agent-core library makes HTTP requests that add AbortSignal listeners. With multiple iterations, this exceeds the default limit (10). Increase to 20 to silence the warning.